### PR TITLE
Add collaborative report structure and GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -1,0 +1,57 @@
+name: Build report
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Pandoc
+        uses: pandoc/actions/setup@v1
+
+      - name: Install XeLaTeX dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            texlive-xetex \
+            texlive-latex-extra \
+            texlive-fonts-recommended \
+            texlive-bibtex-extra \
+            latexmk
+
+      - name: Verify tool versions
+        run: |
+          pandoc --version
+          xelatex --version
+
+      - name: Build report artifacts
+        run: make all
+
+      - name: Upload PDF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: spatial-ninjas-report-pdf
+          path: build/spatial-ninjas-report.pdf
+          if-no-files-found: error
+
+      - name: Upload HTML artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: spatial-ninjas-report-html
+          path: build/spatial-ninjas-report.html
+          if-no-files-found: error
+
+      - name: Upload merged markdown artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: spatial-ninjas-report-merged-markdown
+          path: build/merged.md
+          if-no-files-found: error

--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -33,7 +33,6 @@ jobs:
           xelatex --version
 
       - name: Inspect TeX packages
-        if: ${{ always() }}
         run: |
           kpsewhich hyperref.sty || true
           kpsewhich hyperxmp.sty || true
@@ -45,32 +44,7 @@ jobs:
         continue-on-error: true
         run: make all
 
-      - name: Build PDF debug tex
-        if: ${{ always() }}
-        run: |
-          mkdir -p build
-          pandoc build/merged.md \
-            --from=markdown --standalone --citeproc \
-            --metadata-file=report-metadata.yaml \
-            --bibliography=references.bib \
-            --metadata=date:"March 20, 2026" \
-            --csl=template/ieee.csl \
-            --resource-path=.:docs:template:build \
-            --toc --number-sections \
-            --include-in-header=template/header.tex \
-            -t latex \
-            -o build/debug.tex
-
-      - name: Upload debug tex
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: debug-tex
-          path: build/debug.tex
-          if-no-files-found: warn
-
       - name: Upload PDF artifact
-        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: spatial-ninjas-report-pdf
@@ -78,7 +52,6 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload HTML artifact
-        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: spatial-ninjas-report-html
@@ -86,7 +59,6 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload merged markdown artifact
-        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: spatial-ninjas-report-merged-markdown

--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -32,6 +32,14 @@ jobs:
           pandoc --version
           xelatex --version
 
+      - name: Inspect TeX packages
+        if: ${{ always() }}
+        run: |
+          kpsewhich hyperref.sty || true
+          kpsewhich hyperxmp.sty || true
+          kpsewhich bookmark.sty || true
+          xelatex --version || true
+
       - name: Build report artifacts
         id: build_report
         continue-on-error: true

--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -33,25 +33,60 @@ jobs:
           xelatex --version
 
       - name: Build report artifacts
+        id: build_report
+        continue-on-error: true
         run: make all
 
+      - name: Build PDF debug tex
+        if: ${{ always() }}
+        run: |
+          mkdir -p build
+          pandoc build/merged.md \
+            --from=markdown --standalone --citeproc \
+            --metadata-file=report-metadata.yaml \
+            --bibliography=references.bib \
+            --metadata=date:"March 20, 2026" \
+            --csl=template/ieee.csl \
+            --resource-path=.:docs:template:build \
+            --toc --number-sections \
+            --include-in-header=template/header.tex \
+            -t latex \
+            -o build/debug.tex
+
+      - name: Upload debug tex
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-tex
+          path: build/debug.tex
+          if-no-files-found: warn
+
       - name: Upload PDF artifact
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: spatial-ninjas-report-pdf
           path: build/spatial-ninjas-report.pdf
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Upload HTML artifact
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: spatial-ninjas-report-html
           path: build/spatial-ninjas-report.html
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Upload merged markdown artifact
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: spatial-ninjas-report-merged-markdown
           path: build/merged.md
-          if-no-files-found: error
+          if-no-files-found: warn
+
+      - name: Fail job if build failed
+        if: ${{ steps.build_report.outcome == 'failure' }}
+        run: |
+          echo "make all failed"
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+build/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,94 @@
+# ---------- Config ----------
+PANDOC       := pandoc
+PDF_ENGINE   := xelatex
+
+BUILD_DIR    := build
+DOCS_DIR     := docs
+TEMPLATE_DIR := template
+
+METADATA     := report-metadata.yaml
+HEADER       := $(TEMPLATE_DIR)/header.tex
+BIB_FILE     := references.bib
+CSL_FILE     := $(TEMPLATE_DIR)/ieee.csl
+
+MERGED_MD    := $(BUILD_DIR)/merged.md
+PDF_OUTPUT   := $(BUILD_DIR)/spatial-ninjas-report.pdf
+HTML_OUTPUT  := $(BUILD_DIR)/spatial-ninjas-report.html
+
+# ---------- Source discovery ----------
+FRONTMATTER  := $(sort $(wildcard $(DOCS_DIR)/00-frontmatter/*.md))
+MEMBER_NOTES := $(sort $(wildcard $(DOCS_DIR)/members/*/*.md))
+SHARED_NOTES := $(sort $(wildcard $(DOCS_DIR)/shared/*.md))
+BACKMATTER   := $(sort $(wildcard $(DOCS_DIR)/99-backmatter/*.md))
+
+SOURCES      := $(FRONTMATTER) $(MEMBER_NOTES) $(SHARED_NOTES) $(BACKMATTER)
+
+# ---------- Pandoc flags ----------
+PANDOC_COMMON_FLAGS := \
+	--from=markdown \
+	--standalone \
+	--citeproc \
+	--metadata-file=$(METADATA) \
+	--bibliography=$(BIB_FILE) \
+	--metadata=date:"$(shell date "+%B %-d, %Y")" \
+	--csl=$(CSL_FILE) \
+	--resource-path=.:$(DOCS_DIR):$(TEMPLATE_DIR):$(BUILD_DIR) \
+	--toc \
+	--number-sections
+
+PANDOC_PDF_FLAGS := \
+	$(PANDOC_COMMON_FLAGS) \
+	--include-in-header=$(HEADER)
+
+PANDOC_HTML_FLAGS := \
+	$(PANDOC_COMMON_FLAGS)
+
+# ---------- Targets ----------
+.PHONY: help all pdf html merge clean sources check
+
+help: ## Show available make targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	awk 'BEGIN {FS = ":.*?## "}; {printf "%-15s %s\n", $$1, $$2}'
+
+all: pdf html ## Build all output formats
+
+check: ## Verify required files exist
+	@test -f $(METADATA) || (echo "Missing $(METADATA)"; exit 1)
+	@test -f $(HEADER) || (echo "Missing $(HEADER)"; exit 1)
+	@test -f $(BIB_FILE) || (echo "Missing $(BIB_FILE)"; exit 1)
+	@test -f $(CSL_FILE) || (echo "Missing $(CSL_FILE)"; exit 1)
+
+pdf: $(PDF_OUTPUT) ## Build PDF report
+
+$(PDF_OUTPUT): check $(MERGED_MD) $(METADATA) $(HEADER) $(BIB_FILE) $(CSL_FILE)
+	$(PANDOC) $(MERGED_MD) \
+		$(PANDOC_PDF_FLAGS) \
+		--pdf-engine=$(PDF_ENGINE) \
+		-o $(PDF_OUTPUT)
+
+html: $(HTML_OUTPUT) ## Build HTML report
+
+$(HTML_OUTPUT): check $(MERGED_MD) $(METADATA) $(BIB_FILE) $(CSL_FILE)
+	$(PANDOC) $(MERGED_MD) \
+		$(PANDOC_HTML_FLAGS) \
+		-o $(HTML_OUTPUT)
+
+merge: $(MERGED_MD) ## Merge markdown sources into a single file
+
+$(MERGED_MD): $(SOURCES) | $(BUILD_DIR)
+	@echo "Merging markdown sources..."
+	@rm -f $(MERGED_MD)
+	@for f in $(SOURCES); do \
+		echo "Adding $$f"; \
+		cat $$f >> $(MERGED_MD); \
+		printf '\n\n' >> $(MERGED_MD); \
+	done
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+sources: ## Print detected markdown source files
+	@printf '%s\n' $(SOURCES)
+
+clean: ## Remove build artifacts
+	rm -rf $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -6,23 +6,95 @@ This repository contains the research workspace for the project
 
 The repository will host materials related to:
 
+- literature reviews and research notes
 - experiment code
 - benchmark implementations
 - datasets used for evaluation
-- research notes and documentation
-- references and literature summaries
+- documentation and project outputs
 
-## Structure
 
-The repository will gradually be organized into the following directories:
+## Report Build System
+
+The project report is written in **Markdown** and compiled using **Pandoc**.
+
+A `Makefile` is provided to automate the process of merging all documentation and generating the final outputs.
+
+## Build the report
+
+To build all report formats:
+
+```bash
+make all
+````
+
+This generates:
 
 ```
-docs/        project documentation, research notes, and project log
-experiments/ experiment scripts and notebooks
-benchmarks/  spatial reasoning benchmark implementations
-datasets/    datasets used for experiments
-scripts/     utilities and evaluation scripts
+build/spatial-ninjas-report.pdf
+build/spatial-ninjas-report.html
 ```
+
+You can also build individual formats:
+
+```bash
+make pdf
+make html
+```
+
+Other useful commands:
+
+```bash
+make merge     # merge markdown sources into build/merged.md
+make sources   # list detected markdown source files
+make clean     # remove build artifacts
+make help      # list available targets
+```
+
+The build pipeline:
+
+1. discovers markdown files in the `docs/` directory
+2. merges them into a single document
+3. runs Pandoc to produce PDF and HTML outputs
+4. formats citations using the IEEE CSL style
+
+
+## Repository Structure
+
+```
+docs/                project documentation and literature summaries
+  00-frontmatter/    report introduction and overview
+  members/           paper summaries written by individual members
+  shared/            synthesis and next steps written collaboratively
+  99-backmatter/     references and appendix
+template/            Pandoc LaTeX header and citation style
+references.bib       shared bibliography database
+report-metadata.yaml document metadata used by Pandoc
+Makefile             report build automation
+```
+
+### Member summaries
+
+Each project member writes their paper summary in:
+
+```
+docs/members/<name>/
+```
+
+These are automatically included in the report during the build process.
+
+### Shared sections
+
+Collaborative sections are stored in:
+
+```
+docs/shared/
+```
+
+Examples include:
+
+* literature synthesis
+* proposed next steps for experiments
+
 
 ## References
 
@@ -31,6 +103,15 @@ Bibliographic references used in the project are stored in:
 ```
 references.bib
 ```
+
+Citations inside markdown files use standard Pandoc citation syntax:
+
+```
+@paper_key
+```
+
+The final report is formatted using the **IEEE citation style**.
+
 
 ## Project Management
 

--- a/docs/00-frontmatter/title.md
+++ b/docs/00-frontmatter/title.md
@@ -1,0 +1,3 @@
+# Overview
+
+This document collects the Spatial Ninjas literature summaries, synthesis notes, and next steps.

--- a/docs/99-backmatter/appendix.md
+++ b/docs/99-backmatter/appendix.md
@@ -1,0 +1,4 @@
+# References {.unnumbered}
+
+::: {#refs}
+:::

--- a/docs/members/eemil/multi-task-benchmark.md
+++ b/docs/members/eemil/multi-task-benchmark.md
@@ -1,0 +1,13 @@
+# LLMs on Geospatial Tasks: Multi-Task Benchmarking
+
+## Summary
+
+Eemil's work. Write something here @xu_evaluating_2025.
+
+## Main contribution
+
+...
+
+## Relevance to our project
+
+...

--- a/docs/members/ki-chun/minds-eye.md
+++ b/docs/members/ki-chun/minds-eye.md
@@ -1,0 +1,13 @@
+# Mind's Eye of LLMs
+
+## Summary
+
+Ki Chun's work. Write something here @wu_mind_2024.
+
+## Main contribution
+
+...
+
+## Relevance to our project
+
+...

--- a/docs/members/oliver/spatial-cognition-llms.md
+++ b/docs/members/oliver/spatial-cognition-llms.md
@@ -1,0 +1,13 @@
+# Spatial Cognition Abilities of LLMs
+
+## Summary
+
+Oliver's work. Write something here @yang_evaluating_2025.
+
+## Main contribution
+
+...
+
+## Relevance to our project
+
+...

--- a/docs/members/pawel/geollm.md
+++ b/docs/members/pawel/geollm.md
@@ -1,0 +1,13 @@
+# GeoLLM: Extracting Geospatial Knowledge from LLMs
+
+## Summary
+
+Pawel's work. Write something here @manvi_geollm_2024.
+
+## Main contribution
+
+...
+
+## Relevance to our project
+
+...

--- a/docs/members/pawel/geollm.md
+++ b/docs/members/pawel/geollm.md
@@ -2,7 +2,11 @@
 
 ## Summary
 
-Pawel's work. Write something here @manvi_geollm_2024.
+Manvi et al. uses a programmatic aproach to test the LLM. 
+In their code they amongst others generate a large JSON file with prompts with coordinates and geographical names. 
+They then ask the LLM with a prefix prompt to answer the questions with a certain number, and they can then evaluate these compared with actual answers from coordinates on an actual map. One of their evaluation methods is the Spearmanr correlation. 
+
+This Spearmanr correlation function is the one that I am currently testing. I had written a modified and simplified code based on their source code but a lighter version which takes their existing prompts file and maps, it generates a CSV file with prompt anwers which are then evaluated by the Spearmanr correlation. So far the codes were tested on Gemma 3, while the plan is to test it on Gemini 3.1 Pro, GPT 5.2, DeepSeek and Llama3 as a open source backup.
 
 ## Main contribution
 

--- a/docs/members/pawel/geollm.md
+++ b/docs/members/pawel/geollm.md
@@ -4,9 +4,9 @@
 
 Manvi et al. uses a programmatic aproach to test the LLM. 
 In their code they amongst others generate a large JSON file with prompts with coordinates and geographical names. 
-They then ask the LLM with a prefix prompt to answer the questions with a certain number, and they can then evaluate these compared with actual answers from coordinates on an actual map. One of their evaluation methods is the Spearmanr correlation. 
+They then ask the LLM with a prefix prompt to answer the questions with a certain number, and they can then evaluate these compared with actual answers from coordinates on an actual map. One of their evaluation methods is the Spearmanr correlation and finding Pearsonr correlation and r^2 value. 
 
-This Spearmanr correlation function is the one that I am currently testing. I had written a modified and simplified code based on their source code but a lighter version which takes their existing prompts file and maps, it generates a CSV file with prompt anwers which are then evaluated by the Spearmanr correlation. So far the codes were tested on Gemma 3, while the plan is to test it on Gemini 3.1 Pro, GPT 5.2, DeepSeek and Llama3 as a open source backup.
+I had written a modified and simplified code based on their source code but a lighter version which takes their existing prompts file and maps, it generates a CSV file with prompt anwers which are then evaluated by the Spearmanr correlation. So far the codes were tested on Gemma 3, while the plan is to test it on Gemini 3.1 Pro, GPT 5.2, DeepSeek and Llama3 as a open source backup.
 
 ## Main contribution
 

--- a/docs/members/topi/llm-geotextcog.md
+++ b/docs/members/topi/llm-geotextcog.md
@@ -1,0 +1,13 @@
+# LLM-GeoTextCog: A Cognitive Enhancement Framework
+
+## Summary
+
+Topi's work. Write something here @wang_llm-geotextcog_2026.
+
+## Main contribution
+
+...
+
+## Relevance to our project
+
+...

--- a/docs/members/totti/chatgpt-geospatial-skills.md
+++ b/docs/members/totti/chatgpt-geospatial-skills.md
@@ -1,0 +1,13 @@
+# Geospatial Skills of ChatGPT
+
+## Summary
+
+Totti's work. Write something here @mooney_towards_2023.
+
+## Main contribution
+
+...
+
+## Relevance to our project
+
+...

--- a/docs/shared/next-steps.md
+++ b/docs/shared/next-steps.md
@@ -1,0 +1,32 @@
+# Next Steps
+
+## Candidate evaluation tasks
+
+Potential tasks for benchmarking spatial reasoning:
+
+- distance estimation between cities
+- direction inference ("Which city lies north of...")
+- route description tasks
+
+## Models to evaluate
+
+Possible models to include:
+
+- GPT-4o
+- Claude
+- Gemini
+- Llama
+
+## Enhancement approaches to test
+
+Based on the literature:
+
+- OpenStreetMap augmentation (GeoLLM)
+- Visualization-of-Thought prompting
+- tool-assisted spatial computation
+
+## Immediate implementation tasks
+
+- build evaluation prompt templates
+- implement benchmark runner
+- design scoring metrics

--- a/docs/shared/synthesis.md
+++ b/docs/shared/synthesis.md
@@ -1,0 +1,26 @@
+# Literature Synthesis
+
+## Categories of spatial reasoning tasks
+
+Across the surveyed papers, spatial reasoning tasks can be grouped into:
+
+- distance estimation
+- direction inference
+- topological relationships
+- map-based question answering
+
+## Evaluation approaches
+
+Three main evaluation approaches appear:
+
+- benchmark datasets (Xu et al.)
+- prompting techniques (Wu et al.)
+- external knowledge integration (Manvi et al.)
+
+## Common weaknesses of LLMs
+
+Several studies report similar failure modes:
+
+- inconsistent distance estimation
+- confusion between relative directions
+- hallucinated geographic facts

--- a/report-metadata.yaml
+++ b/report-metadata.yaml
@@ -1,0 +1,29 @@
+title: "LLM Spatial Reasoning: Evaluating and Enhancing Geographic Cognition in Language Models"
+subtitle: "Spatial Ninjas — Course Project Report"
+
+author:
+  - Ki Chun Tong
+  - Pawel Dzierzynski
+  - Oliver Isaksson
+  - Eemil Koskinen
+  - Topi Nieminen
+  - Totti L.
+
+date: $date$
+lang: en
+
+keywords:
+  - spatial reasoning
+  - large language models
+  - geospatial cognition
+  - GeoAI
+
+abstract: |
+  This report evaluates the spatial reasoning capabilities of large language
+  models and explores methods to improve geographic cognition in LLM-based
+  systems.
+
+link-citations: true
+toc: true
+toc-depth: 2
+number-sections: true

--- a/template/header.tex
+++ b/template/header.tex
@@ -1,0 +1,19 @@
+\usepackage[margin=1in]{geometry}
+\usepackage{parskip}
+\setlength{\parindent}{0pt}
+\usepackage{graphicx}
+\usepackage{booktabs}
+\usepackage{longtable}
+\usepackage{xcolor}
+\usepackage{hyperref}
+\usepackage{microtype}
+
+\hypersetup{
+  colorlinks=true,
+  linkcolor=blue,
+  urlcolor=blue,
+  citecolor=blue
+}
+
+\usepackage{etoolbox}
+\pretocmd{\section}{\clearpage}{}{}

--- a/template/header.tex
+++ b/template/header.tex
@@ -17,3 +17,5 @@
 
 \usepackage{etoolbox}
 \pretocmd{\section}{\clearpage}{}{}
+
+\providecommand{\xmpquote}[1]{#1}

--- a/template/ieee.csl
+++ b/template/ieee.csl
@@ -1,0 +1,519 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
+  <info>
+    <title>IEEE Reference Guide version 11.29.2023</title>
+    <title-short>Institute of Electrical and Electronics Engineers</title-short>
+    <id>http://www.zotero.org/styles/ieee</id>
+    <link href="http://www.zotero.org/styles/ieee" rel="self"/>
+    <link href="https://journals.ieeeauthorcenter.ieee.org/your-role-in-article-production/ieee-editorial-style-manual/" rel="documentation"/>
+    <author>
+      <name>Michael Berkowitz</name>
+      <email>mberkowi@gmu.edu</email>
+    </author>
+    <contributor>
+      <name>Julian Onions</name>
+      <email>julian.onions@gmail.com</email>
+    </contributor>
+    <contributor>
+      <name>Rintze Zelle</name>
+      <uri>http://twitter.com/rintzezelle</uri>
+    </contributor>
+    <contributor>
+      <name>Stephen Frank</name>
+      <uri>http://www.zotero.org/sfrank</uri>
+    </contributor>
+    <contributor>
+      <name>Sebastian Karcher</name>
+    </contributor>
+    <contributor>
+      <name>Giuseppe Silano</name>
+      <email>g.silano89@gmail.com</email>
+      <uri>http://giuseppesilano.net</uri>
+    </contributor>
+    <contributor>
+      <name>Patrick O'Brien</name>
+    </contributor>
+    <contributor>
+      <name>Brenton M. Wiernik</name>
+    </contributor>
+    <contributor>
+      <name>Oliver Couch</name>
+      <email>oliver.couch@gmail.com</email>
+    </contributor>
+    <contributor>
+      <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
+    </contributor>
+    <category citation-format="numeric"/>
+    <category field="engineering"/>
+    <category field="generic-base"/>
+    <summary>IEEE style as per the 2023 guidelines.</summary>
+    <updated>2026-01-07T15:36:59+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <date form="text">
+      <date-part name="month" form="short" suffix=" "/>
+      <date-part name="day" form="numeric-leading-zeros" suffix=", "/>
+      <date-part name="year"/>
+    </date>
+    <terms>
+      <term name="chapter" form="short">ch.</term>
+      <term name="chapter-number" form="short">ch.</term>
+      <term name="presented at">presented at the</term>
+      <term name="available at">available</term>
+      <!-- always use three-letter abbreviations for months -->
+      <term name="month-06" form="short">Jun.</term>
+      <term name="month-07" form="short">Jul.</term>
+      <term name="month-09" form="short">Sep.</term>
+    </terms>
+  </locale>
+  <!-- Macros -->
+  <macro name="status">
+    <choose>
+      <if variable="page issue volume" match="none">
+        <text variable="status" text-case="capitalize-first" suffix="" font-weight="bold"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" text-case="capitalize-first" suffix="."/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="article-journal report" match="any">
+        <date variable="issued">
+          <date-part name="month" form="short" suffix=" "/>
+          <date-part name="year" form="long"/>
+        </date>
+      </if>
+      <else-if type="bill book chapter graphic legal_case legislation song thesis" match="any">
+        <date variable="issued">
+          <date-part name="year" form="long"/>
+        </date>
+      </else-if>
+      <else-if type="paper-conference" match="any">
+        <date variable="issued">
+          <date-part name="month" form="short"/>
+          <date-part name="year" prefix=" "/>
+        </date>
+      </else-if>
+      <else-if type="motion_picture" match="any">
+        <date variable="issued" form="text" prefix="(" suffix=")"/>
+      </else-if>
+      <else>
+        <date variable="issued" form="text"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name and="text" et-al-min="7" et-al-use-first="1" initialize-with=". "/>
+      <label form="short" prefix=", " text-case="capitalize-first"/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="director"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <name initialize-with=". " delimiter=", " and="text"/>
+      <label form="short" prefix=", " text-case="capitalize-first"/>
+    </names>
+  </macro>
+  <macro name="director">
+    <names variable="director">
+      <name and="text" et-al-min="7" et-al-use-first="1" initialize-with=". "/>
+      <et-al font-style="italic"/>
+    </names>
+  </macro>
+  <macro name="locators">
+    <group delimiter=", ">
+      <text macro="edition"/>
+      <group delimiter=" ">
+        <text term="volume" form="short"/>
+        <number variable="volume" form="numeric"/>
+      </group>
+      <group delimiter=" ">
+        <number variable="number-of-volumes" form="numeric"/>
+        <text term="volume" form="short" plural="true"/>
+      </group>
+      <group delimiter=" ">
+        <text term="issue" form="short"/>
+        <number variable="issue" form="numeric"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture song standard software" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=", ">
+          <text variable="publisher"/>
+          <text variable="publisher-place"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <!-- Published Conference Paper -->
+      <if type="paper-conference speech" match="any">
+        <choose>
+          <if variable="container-title" match="any">
+            <group delimiter=" ">
+              <text term="in"/>
+              <text variable="container-title" font-style="italic"/>
+            </group>
+          </if>
+          <!-- Unpublished Conference Paper -->
+          <else>
+            <group delimiter=" ">
+              <text term="presented at"/>
+              <text variable="event"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="webpage post post-weblog" match="any">
+        <!-- https://url.com/ (accessed Mon. DD, YYYY). -->
+        <choose>
+          <if variable="URL">
+            <group delimiter=". " prefix=" ">
+              <group delimiter=": ">
+                <text term="accessed" text-case="capitalize-first"/>
+                <date variable="accessed" form="text"/>
+              </group>
+              <text term="online" prefix="[" suffix="]" text-case="capitalize-first"/>
+              <group delimiter=": ">
+                <text term="available at" text-case="capitalize-first"/>
+                <text variable="URL"/>
+              </group>
+            </group>
+          </if>
+        </choose>
+      </if>
+      <else-if match="any" variable="DOI">
+        <!-- doi: 10.1000/xyz123. -->
+        <text variable="DOI" prefix=" doi: " suffix="."/>
+      </else-if>
+      <else-if variable="URL">
+        <!-- Accessed: Mon. DD, YYYY. [Medium]. Available: https://URL.com/ -->
+        <group delimiter=". " prefix=" " suffix=". ">
+          <!-- Accessed: Mon. DD, YYYY. -->
+          <group delimiter=": ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date variable="accessed" form="text"/>
+          </group>
+          <!-- [Online Video]. -->
+          <group prefix="[" suffix="]" delimiter=" ">
+            <choose>
+              <if variable="medium" match="any">
+                <text variable="medium" text-case="capitalize-first"/>
+              </if>
+              <else>
+                <text term="online" text-case="capitalize-first"/>
+                <choose>
+                  <if type="motion_picture">
+                    <text term="video" text-case="capitalize-first"/>
+                  </if>
+                </choose>
+              </else>
+            </choose>
+          </group>
+        </group>
+        <!-- Available: https://URL.com/ -->
+        <group delimiter=": " prefix=" ">
+          <text term="available at" text-case="capitalize-first"/>
+          <text variable="URL"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="page">
+    <choose>
+      <if type="article-journal" variable="number" match="all">
+        <group delimiter=" ">
+          <text value="Art."/>
+          <text term="issue" form="short"/>
+          <text variable="number"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <label variable="page" form="short"/>
+          <text variable="page"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="citation-locator">
+    <group delimiter=" ">
+      <choose>
+        <if locator="page">
+          <label variable="locator" form="short"/>
+        </if>
+        <else>
+          <label variable="locator" form="short" text-case="capitalize-first"/>
+        </else>
+      </choose>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="geographic-location">
+    <group delimiter=", " suffix=".">
+      <choose>
+        <if variable="publisher-place">
+          <text variable="publisher-place" text-case="title"/>
+        </if>
+        <else-if variable="event-place">
+          <text variable="event-place" text-case="title"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <!-- Series -->
+  <macro name="collection">
+    <choose>
+      <if variable="collection-title" match="any">
+        <text term="in" suffix=" "/>
+        <group delimiter=", " suffix=". ">
+          <text variable="collection-title"/>
+          <text variable="collection-number" prefix="no. "/>
+          <text variable="volume" prefix="vol. "/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <!-- Citation -->
+  <citation>
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout delimiter=", ">
+      <group prefix="[" suffix="]" delimiter=", ">
+        <text variable="citation-number"/>
+        <text macro="citation-locator"/>
+      </group>
+    </layout>
+  </citation>
+  <!-- Bibliography -->
+  <bibliography entry-spacing="0" second-field-align="flush">
+    <layout>
+      <!-- Citation Number -->
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <!-- Author(s) -->
+      <text macro="author" suffix=", "/>
+      <!-- Rest of Citation -->
+      <choose>
+        <!-- Specific Formats -->
+        <if type="article-journal">
+          <group delimiter=", ">
+            <text macro="title"/>
+            <text variable="container-title" font-style="italic" form="short"/>
+            <text macro="locators"/>
+            <text macro="page"/>
+            <text macro="issued"/>
+            <text macro="status"/>
+          </group>
+          <choose>
+            <if variable="URL DOI" match="none">
+              <text value="."/>
+            </if>
+            <else>
+              <text value=","/>
+            </else>
+          </choose>
+          <text macro="access"/>
+        </if>
+        <else-if type="paper-conference speech" match="any">
+          <group delimiter=", " suffix=", ">
+            <text macro="title"/>
+            <text macro="event"/>
+            <text macro="editor"/>
+          </group>
+          <text macro="collection"/>
+          <group delimiter=", " suffix=".">
+            <text macro="publisher"/>
+            <text macro="issued"/>
+            <text macro="page"/>
+            <text macro="status"/>
+          </group>
+          <text macro="access"/>
+        </else-if>
+        <else-if type="chapter">
+          <group delimiter=", " suffix=".">
+            <text macro="title"/>
+            <group delimiter=" ">
+              <text term="in" suffix=" "/>
+              <text variable="container-title" font-style="italic"/>
+            </group>
+            <text macro="locators"/>
+            <text macro="editor"/>
+            <text macro="collection"/>
+            <text macro="publisher"/>
+            <text macro="issued"/>
+            <group delimiter=" ">
+              <label variable="chapter-number" form="short"/>
+              <text variable="chapter-number"/>
+            </group>
+            <text macro="page"/>
+          </group>
+          <text macro="access"/>
+        </else-if>
+        <else-if type="report">
+          <group delimiter=", " suffix=".">
+            <text macro="title"/>
+            <text macro="publisher"/>
+            <group delimiter=" ">
+              <text variable="genre"/>
+              <text variable="number"/>
+            </group>
+            <text macro="issued"/>
+          </group>
+          <text macro="access"/>
+        </else-if>
+        <else-if type="thesis">
+          <group delimiter=", " suffix=".">
+            <text macro="title"/>
+            <text variable="genre"/>
+            <text macro="publisher"/>
+            <text macro="issued"/>
+          </group>
+          <text macro="access"/>
+        </else-if>
+        <else-if type="software">
+          <group delimiter=". " suffix=".">
+            <text macro="title"/>
+            <text macro="issued" prefix="(" suffix=")"/>
+            <text variable="genre"/>
+            <text macro="publisher"/>
+          </group>
+          <text macro="access"/>
+        </else-if>
+        <else-if type="article">
+          <group delimiter=", " suffix=".">
+            <text macro="title"/>
+            <text macro="issued"/>
+            <group delimiter=": ">
+              <text macro="publisher" font-style="italic"/>
+              <text variable="number"/>
+            </group>
+          </group>
+          <text macro="access"/>
+        </else-if>
+        <else-if type="webpage post-weblog post" match="any">
+          <group delimiter=", " suffix=".">
+            <text macro="title"/>
+            <text variable="container-title"/>
+          </group>
+          <text macro="access"/>
+        </else-if>
+        <else-if type="patent">
+          <group delimiter=", ">
+            <text macro="title"/>
+            <text variable="number"/>
+            <text macro="issued"/>
+          </group>
+          <text macro="access"/>
+        </else-if>
+        <!-- Online Video -->
+        <else-if type="motion_picture">
+          <text macro="geographic-location" suffix=". "/>
+          <group delimiter=", " suffix=".">
+            <text macro="title"/>
+            <text macro="issued"/>
+          </group>
+          <text macro="access"/>
+        </else-if>
+        <else-if type="standard">
+          <group delimiter=", " suffix=".">
+            <text macro="title"/>
+            <group delimiter=" ">
+              <text variable="genre"/>
+              <text variable="number"/>
+            </group>
+            <text macro="geographic-location"/>
+            <text macro="issued"/>
+          </group>
+          <text macro="access"/>
+        </else-if>
+        <!-- Generic/Fallback Formats -->
+        <else-if type="bill book graphic legal_case legislation report song" match="any">
+          <group delimiter=", " suffix=". ">
+            <text macro="title"/>
+            <text macro="locators"/>
+          </group>
+          <text macro="collection"/>
+          <group delimiter=", " suffix=".">
+            <text macro="publisher"/>
+            <text macro="issued"/>
+            <text macro="page"/>
+          </group>
+          <text macro="access"/>
+        </else-if>
+        <else-if type="article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage" match="any">
+          <group delimiter=", " suffix=".">
+            <text macro="title"/>
+            <text variable="container-title" font-style="italic"/>
+            <text macro="locators"/>
+            <text macro="publisher"/>
+            <text macro="page"/>
+            <text macro="issued"/>
+          </group>
+          <text macro="access"/>
+        </else-if>
+        <else>
+          <group delimiter=", " suffix=". ">
+            <text macro="title"/>
+            <text variable="container-title" font-style="italic"/>
+            <text macro="locators"/>
+          </group>
+          <text macro="collection"/>
+          <group delimiter=", " suffix=".">
+            <text macro="publisher"/>
+            <text macro="page"/>
+            <text macro="issued"/>
+          </group>
+          <text macro="access"/>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
This PR sets up an initial **documentation and report-building workflow** that we can consider adopting as one way to organize our project documentation.

The idea is to keep the report in **Markdown**, let each member contribute their own literature notes in a structured folder layout, and use **Pandoc** to merge everything into a single report in **PDF** and **HTML** format. The PR also adds a **GitHub Actions workflow** so the report can be built automatically and shared as artifacts.

## What this proposes

* a possible documentation structure under `docs/` for:
  * frontmatter
  * individual member literature summaries
  * shared synthesis and next steps
  * references / backmatter
* a `Makefile` to support:
  * automatic markdown source discovery
  * merging all report sections into one file
  * building PDF and HTML outputs
  * utility commands such as `make help`, `make sources`, and `make clean`
* a CI workflow that:
  * installs Pandoc and LaTeX dependencies
  * builds the report automatically on push, PR, or manual trigger
  * uploads the generated outputs as artifacts
* shared report configuration through:
  * `report-metadata.yaml`
  * a LaTeX header file
  * IEEE citation style
* README updates explaining how this documentation approach works and how to build the outputs locally

## Why this may be useful

This is not necessarily the only documentation approach we should use, but it is one concrete option we can consider. It gives us:

* a reproducible way to turn distributed notes into one report
* a clearer separation between individual contributions and shared writing
* automatic build verification in CI
* a lightweight workflow based on Markdown instead of heavier authoring tools
